### PR TITLE
Use phoenix master

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule PhoenixLiveReload.Mixfile do
 
   defp deps do
     # TODO bump to phoenix 0.11
-    [{:phoenix, github: "phoenixframework/phoenix", branch: "cm-fs"},
+    [{:phoenix, github: "phoenixframework/phoenix"},
      # TODO use hex version
      {:fs, github: "synrc/fs"}]
   end


### PR DESCRIPTION
Now that `cm-fs` is in `master` new applications are failing to compile.