### PR TITLE
make the live reload iframe invisible

### DIFF
--- a/lib/phoenix_live_reload/live_reloader.ex
+++ b/lib/phoenix_live_reload/live_reloader.ex
@@ -84,7 +84,7 @@ defmodule Phoenix.LiveReloader do
 
   defp reload_assets_tag() do
     """
-    <iframe src="/phoenix/live_reload/frame" width="0" height="0" scrolling="no" frameborder="0" style="display: none;"></iframe>
+    <iframe src="/phoenix/live_reload/frame" style="display: none;"></iframe>
     """
   end
 end

--- a/lib/phoenix_live_reload/live_reloader.ex
+++ b/lib/phoenix_live_reload/live_reloader.ex
@@ -84,7 +84,7 @@ defmodule Phoenix.LiveReloader do
 
   defp reload_assets_tag() do
     """
-    <iframe src="/phoenix/live_reload/frame" width="0" height="0" scrolling="no" frameborder="0"></iframe>
+    <iframe src="/phoenix/live_reload/frame" width="0" height="0" scrolling="no" frameborder="0" style="display: none;"></iframe>
     """
   end
 end


### PR DESCRIPTION
Some user agents have default styles for the `<body>` element. Chrome for example has `margin: 8px;`. That means that if the live reload iframe is present the css of the site could be screwed in dev mode. This should fix this.