### PR TITLE
Changes css reloading to insert a new dom element

### DIFF
--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -1,26 +1,36 @@
-var buildFreshUrl = function(url) {
+var buildFreshUrl = function(link) {
   var date = Math.round(Date.now() / 1000).toString();
-  url = url.replace(/(\&|\\?)vsn=\d*/, '');
-  return url + (url.indexOf('?') >= 0 ? '&' : '?') +'vsn=' + date;
+  var url = link.href.replace(/(\&|\\?)vsn=\d*/, '');
+
+  l = document.createElement('link');
+  l.setAttribute('rel', 'stylesheet');
+  l.setAttribute('type', 'text/css');
+  l.setAttribute('href', url + (url.indexOf('?') >= 0 ? '&' : '?') +'vsn=' + date);
+  top.document.head.appendChild(l);
+
+  l.onload = function(){
+    link.remove();
+  };
+
+  return l;
 };
 
 var repaint = function() {
   var browser = navigator.userAgent.toLowerCase();
-
   if(browser.indexOf('chrome') > -1) setTimeout( function() { document.body.offsetHeight; }, 25);
 };
 
 var cssStrategy = function() {
   [].slice
-    .call(window.top.document.querySelectorAll('link[rel=stylesheet]'))
+    .call(window.top.document.querySelectorAll('link[rel=stylesheet]:not([data-no-reload])'))
     .filter(function(link) { return link.href })
-    .forEach(function(link) { link.href = buildFreshUrl(link.href) });
+    .forEach(function(link) { buildFreshUrl(link) });
 
   repaint();
 };
 
 var defaultStrategy = function(chan) {
-  chan.off("assets_change");
+  chan.off('assets_change');
   window.top.location.reload();
 };
 
@@ -30,8 +40,8 @@ var reloadStrategies = {
 };
 
 socket.connect();
-var chan = socket.chan("phoenix:live_reload", {})
-chan.on("assets_change", function(msg) {
+var chan = socket.chan('phoenix:live_reload', {})
+chan.on('assets_change', function(msg) {
   var reloadStrategy = reloadStrategies[msg.asset_type] || reloadStrategies.default;
   reloadStrategy(chan);
 });


### PR DESCRIPTION
- To prevent white flashes on heavy pages, it's better to add a new dom element with the new style and then remove the old once the new one has loaded
- Introduces the data-no-reload option to prevent unwanted reloads