### PR TITLE
Insert the new <link> after the one it replaces

### DIFF
--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -6,7 +6,8 @@ var buildFreshUrl = function(link){
   newLink.setAttribute('rel', 'stylesheet');
   newLink.setAttribute('type', 'text/css');
   newLink.setAttribute('href', url + (url.indexOf('?') >= 0 ? '&' : '?') +'vsn=' + date);
-  window.top.document.head.appendChild(newLink);
+  link.parentNode.insertBefore(newLink, link.nextSibling);
+
   newLink.onload = function(){ link.remove() }
 
   return newLink;


### PR DESCRIPTION
Some users might have stylesheets not loaded within <head> so appending to <head> might cause unexpected behavior.