### PR TITLE
Use 'channel' rather than 'chan' and upgrade to phoenix 0.16

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule PhoenixLiveReload.Mixfile do
   end
 
   defp deps do
-    [{:phoenix, "~> 0.15"},
+    [{:phoenix, "~> 0.16"},
      {:fs, "~> 0.9.1"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{"fs": {:hex, :fs, "0.9.2"},
-  "phoenix": {:hex, :phoenix, "0.15.0"},
-  "plug": {:hex, :plug, "0.13.1"},
+  "phoenix": {:hex, :phoenix, "0.16.1"},
+  "plug": {:hex, :plug, "0.14.0"},
   "poison": {:hex, :poison, "1.4.0"}}

--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -44,7 +44,7 @@ var reloadStrategies = {
 };
 
 socket.connect();
-var chan = socket.chan('phoenix:live_reload', {})
+var chan = socket.channel('phoenix:live_reload', {})
 chan.on('assets_change', function(msg) {
   var reloadStrategy = reloadStrategies[msg.asset_type] || reloadStrategies.default;
   reloadStrategy(chan);


### PR DESCRIPTION
I ran into a problem where live_reloader still uses the "old" JavaScript API for channels.
This fixes it.

Should also bump the version of `phoenix_live_reload` itself?