### PR TITLE
Remove usage of reserved word

### DIFF
--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -35,20 +35,20 @@ var cssStrategy = function(){
   repaint();
 };
 
-var defaultStrategy = function(chan){
+var pageStrategy = function(chan){
   chan.off('assets_change');
   window.top.location.reload();
 };
 
 var reloadStrategies = {
   css: cssStrategy,
-  default: defaultStrategy
+  page: pageStrategy
 };
 
 socket.connect();
 var chan = socket.channel('phoenix:live_reload', {})
 chan.on('assets_change', function(msg) {
-  var reloadStrategy = reloadStrategies[msg.asset_type] || reloadStrategies.default;
+  var reloadStrategy = reloadStrategies[msg.asset_type] || reloadStrategy.page;
   reloadStrategy(chan);
 });
 chan.join();


### PR DESCRIPTION
The word `default` is a [reserved word](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-keywords), and should not be used as an object key (without being in quotes).

In at least IE9, this throws an error.

![image](https://cloud.githubusercontent.com/assets/2391584/11346931/06a2ce18-91d4-11e5-96fe-46de6983b365.png)

Came across this as I was doing some cross-browser compatibility testing.