### PR TITLE
Handle script_name when matching paths

### DIFF
--- a/lib/phoenix_live_reload/live_reloader.ex
+++ b/lib/phoenix_live_reload/live_reloader.ex
@@ -60,11 +60,7 @@ defmodule Phoenix.LiveReloader do
     opts
   end
 
-  def call(conn, _opts) do
-    dispatch(conn.path_info -- conn.script_name, conn)
-  end
-
-  def dispatch(["phoenix", "live_reload", "frame"], conn) do
+  def call(%Plug.Conn{path_info: ["phoenix", "live_reload", "frame"]} = conn , _) do
     endpoint = conn.private.phoenix_endpoint
     config = endpoint.config(:live_reload)
     url    = config[:url] || endpoint.path("/phoenix/live_reload/socket")
@@ -75,10 +71,7 @@ defmodule Phoenix.LiveReloader do
       <html><body>
       <script>
         #{@phoenix_js}
-
-        var phx = require("phoenix")
-        var socket = new phx.Socket("#{url}")
-
+        var socket = new Phoenix.Socket("#{url}")
         #{@phoenix_live_reload_js}
       </script>
       </body></html>
@@ -86,7 +79,7 @@ defmodule Phoenix.LiveReloader do
     |> halt()
   end
 
-  def dispatch(_path_info, conn) do
+  def call(conn, _) do
     patterns = get_in conn.private.phoenix_endpoint.config(:live_reload), [:patterns]
     if patterns && patterns != [] do
       before_send_inject_reloader(conn)

--- a/lib/phoenix_live_reload/live_reloader.ex
+++ b/lib/phoenix_live_reload/live_reloader.ex
@@ -60,7 +60,11 @@ defmodule Phoenix.LiveReloader do
     opts
   end
 
-  def call(%Plug.Conn{path_info: ["phoenix", "live_reload", "frame"]} = conn, _opts) do
+  def call(conn, _opts) do
+    dispatch(conn.path_info -- conn.script_name, conn)
+  end
+
+  def dispatch(["phoenix", "live_reload", "frame"], conn) do
     config = conn.private.phoenix_endpoint.config(:live_reload)
     url    = Path.join(config[:url] || "/", "phoenix/live_reload/socket")
 
@@ -81,7 +85,7 @@ defmodule Phoenix.LiveReloader do
     |> halt()
   end
 
-  def call(conn, _opts) do
+  def dispatch(_path_info, conn) do
     patterns = get_in conn.private.phoenix_endpoint.config(:live_reload), [:patterns]
     if patterns && patterns != [] do
       before_send_inject_reloader(conn)

--- a/lib/phoenix_live_reload/live_reloader.ex
+++ b/lib/phoenix_live_reload/live_reloader.ex
@@ -65,8 +65,9 @@ defmodule Phoenix.LiveReloader do
   end
 
   def dispatch(["phoenix", "live_reload", "frame"], conn) do
-    config = conn.private.phoenix_endpoint.config(:live_reload)
-    url    = Path.join(config[:url] || "/", "phoenix/live_reload/socket")
+    endpoint = conn.private.phoenix_endpoint
+    config = endpoint.config(:live_reload)
+    url    = config[:url] || endpoint.path("/phoenix/live_reload/socket")
 
     conn
     |> put_resp_content_type("text/html")

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule PhoenixLiveReload.Mixfile do
   end
 
   defp deps do
-    [{:phoenix, "~> 0.16 or ~> 1.0"},
+    [{:phoenix, "~> 1.1.2"},
      {:ex_doc, "~> 0.7.1", only: :docs},
      {:fs, "~> 0.9.1"}]
   end

--- a/test/phoenix_live_reload_test.exs
+++ b/test/phoenix_live_reload_test.exs
@@ -23,7 +23,21 @@ defmodule PhoenixLiveReloadTest do
            ~s[require("phoenix")]
     refute to_string(conn.resp_body) =~
            ~s[<iframe src="/phoenix/live_reload/frame"]
+
   end
+
+  test "renders frame with phoenix.js with script_name" do
+    conn = conn("/foo/bar/phoenix/live_reload/frame")
+           |> Map.put(:script_name, ["foo", "bar"])
+           |> Phoenix.LiveReloader.call([])
+
+    assert conn.status == 200
+    assert to_string(conn.resp_body) =~
+           ~s[require("phoenix")]
+    refute to_string(conn.resp_body) =~
+           ~s[<iframe src="/phoenix/live_reload/frame"]
+  end
+
 
   test "injects live_reload for html requests if configured and contains <body> tag" do
     opts = Phoenix.LiveReloader.init([])

--- a/test/phoenix_live_reload_test.exs
+++ b/test/phoenix_live_reload_test.exs
@@ -20,24 +20,11 @@ defmodule PhoenixLiveReloadTest do
 
     assert conn.status == 200
     assert to_string(conn.resp_body) =~
-           ~s[require("phoenix")]
+           ~s[Phoenix.Socket]
     refute to_string(conn.resp_body) =~
-           ~s[<iframe src="/phoenix/live_reload/frame"]
+           ~s[<iframe]
 
   end
-
-  test "renders frame with phoenix.js with script_name" do
-    conn = conn("/foo/bar/phoenix/live_reload/frame")
-           |> Map.put(:script_name, ["foo", "bar"])
-           |> Phoenix.LiveReloader.call([])
-
-    assert conn.status == 200
-    assert to_string(conn.resp_body) =~
-           ~s[require("phoenix")]
-    refute to_string(conn.resp_body) =~
-           ~s[<iframe src="/phoenix/live_reload/frame"]
-  end
-
 
   test "injects live_reload for html requests if configured and contains <body> tag" do
     opts = Phoenix.LiveReloader.init([])
@@ -48,6 +35,18 @@ defmodule PhoenixLiveReloadTest do
     assert to_string(conn.resp_body) ==
       "<html><body><h1>Phoenix</h1><iframe src=\"/phoenix/live_reload/frame\" style=\"display: none;\"></iframe>\n</body></html>"
   end
+
+  test "injects live_reload with script_name" do
+    opts = Phoenix.LiveReloader.init([])
+    conn = conn("/")
+           |> put_private(:phoenix_endpoint, MyApp.EndpointScript)
+           |> put_resp_content_type("text/html")
+           |> Phoenix.LiveReloader.call(opts)
+           |> send_resp(200, "<html><body><h1>Phoenix</h1></body></html>")
+    assert to_string(conn.resp_body) ==
+      "<html><body><h1>Phoenix</h1><iframe src=\"/foo/bar/phoenix/live_reload/frame\" style=\"display: none;\"></iframe>\n</body></html>"
+  end
+
 
   test "skips live_reload injection if html response missing body tag" do
     opts = Phoenix.LiveReloader.init([])

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,9 +8,21 @@ Application.put_env(:phoenix_live_reload, MyApp.Endpoint,
        ~r{web/templates/.*(eex)$}
      ]])
 
+Application.put_env(:phoenix_live_reload, MyApp.EndpointScript, [
+  live_reload: [
+    url: "ws://localhost:4000",
+    patterns: [~r{priv/static/.*(js|css|png|jpeg|jpg|gif)$}]
+  ],
+  url: [path: "/foo/bar"],
+])
+
 defmodule MyApp.Endpoint do
+  use Phoenix.Endpoint, otp_app: :phoenix_live_reload
+end
+defmodule MyApp.EndpointScript do
   use Phoenix.Endpoint, otp_app: :phoenix_live_reload
 end
 
 MyApp.Endpoint.start_link()
+MyApp.EndpointScript.start_link()
 ExUnit.start()


### PR DESCRIPTION
We had the report of an issue with mounting phoenix at a path, using the `path:` Endpoints url path option. The "/phoenix/live_reload" frame would 404 because it does not take script_name into consideration with the path. @josevalim 2nd pair of eyes please.