### PR TITLE
fix live reload for project names containing `_build`

### DIFF
--- a/lib/phoenix_live_reload/channel.ex
+++ b/lib/phoenix_live_reload/channel.ex
@@ -28,7 +28,7 @@ defmodule Phoenix.LiveReload.Channel do
     path = to_string(path)
 
     Enum.any?(patterns, fn pattern ->
-      String.match?(path, pattern) and !String.match?(path, ~r/_build/)
+      String.match?(path, pattern) and !String.match?(path, ~r{(^|/)_build/})
     end)
   end
 end

--- a/test/channel_test.exs
+++ b/test/channel_test.exs
@@ -39,6 +39,11 @@ defmodule Phoenix.LiveReload.ChannelTest do
     refute_receive _anything, 100
   end
 
+  test "it allows project names containing _build", %{socket: socket} do
+    send socket.channel_pid, file_event("/Users/auser/www/widget_builder/web/templates/layout/app.html.eex", :created)
+    assert_push "assets_change", %{asset_type: "eex"}
+  end
+
   test "sends notification for js", %{socket: socket} do
     send socket.channel_pid, file_event("priv/static/phoenix_live_reload.js", :created)
     assert_push "assets_change", %{asset_type: "js"}


### PR DESCRIPTION
My project name contains the string `_build`, which was causing live reload to not be triggered due to this regex.  I've made the regex a bit more specific.