### PR TITLE
Update fs dependency to version 3.4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,6 @@ defmodule PhoenixLiveReload.Mixfile do
     [{:phoenix, "~> 1.0 or ~> 1.2-rc"},
      {:ex_doc, "~> 0.11", only: :docs},
      {:earmark, ">= 0.0.0", only: :docs},
-     {:fs, "~> 0.9.1"}]
+     {:fs, "~> 3.4.0"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.4", "a0a79a6896075814f4bc6802b74ccbed6549f47cc5ab34c71eaee2303170b8ef", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
+  "fs": {:hex, :fs, "3.4.0", "6d18575c250b415b3cad559e6f97a4c822516c7bc2c10bfbb2493a8f230f5132", [:rebar3], []},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
   "phoenix": {:hex, :phoenix, "1.2.1", "6dc592249ab73c67575769765b66ad164ad25d83defa3492dc6ae269bd2a68ab", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.1", "c10ddf6237007c804bf2b8f3c4d5b99009b42eca3a0dfac04ea2d8001186056a", [:mix], []},


### PR DESCRIPTION
Notable changes:

* New events has been included for inotifywait, like [`MODIFY`](https://github.com/synrc/fs/commit/8db54f921a1a85e180ec7a03cbf4b76008aa52c0)

Those changes enable the use of Phoenix live-reloading using Docker volumes. As explained in https://github.com/synrc/fs/issues/43.

The current setup does not work because the file-system event `CLOSE_WRITE` is not propagated from the host to the container. More info at: https://github.com/docker/for-mac/issues/896. 

**IMPORTANT:** `fs` was [upgraded in the past](https://github.com/phoenixframework/phoenix_live_reload/pull/43) but reverted due to [rebar build problems](https://github.com/phoenixframework/phoenix_live_reload/commit/e54bf6fb301436797ff589e0b76a047bb79b6870). I couldn't check if those problems are still there because there is no documentation of them :) 
