### PR TITLE
Skip live reload when `resp_body` is nil

### DIFF
--- a/lib/phoenix_live_reload/live_reloader.ex
+++ b/lib/phoenix_live_reload/live_reloader.ex
@@ -91,7 +91,7 @@ defmodule Phoenix.LiveReloader do
 
   defp before_send_inject_reloader(conn, endpoint) do
     register_before_send(conn, fn conn ->
-      if html?(conn) do
+      if conn.resp_body != nil && html?(conn) do
         resp_body = IO.iodata_to_binary(conn.resp_body)
         if has_body?(resp_body) and :code.is_loaded(endpoint) do
           [page | rest] = String.split(resp_body, "</body>")

--- a/test/phoenix_live_reload_test.exs
+++ b/test/phoenix_live_reload_test.exs
@@ -66,4 +66,15 @@ defmodule PhoenixLiveReloadTest do
     refute to_string(conn.resp_body) =~
            ~s(<iframe src="/phoenix/live_reload/frame")
   end
+
+  test "skips live_reload if body is nil" do
+    opts = Phoenix.LiveReloader.init([])
+    conn = conn("/")
+           |> put_resp_content_type("text/html")
+           |> Phoenix.LiveReloader.call(opts)
+           |> send_file(200, Path.join(File.cwd!, "README.md"))
+    assert conn.status == 200
+    refute to_string(conn.resp_body) =~
+           ~s(<iframe src="/phoenix/live_reload/frame")
+  end
 end


### PR DESCRIPTION
Using `send_file` with html is causing errors:

```
** (ArgumentError) argument error
    :erlang.iolist_to_binary(nil)
    (phoenix_live_reload) lib/phoenix_live_reload/live_reloader.ex:95: anonymous fn/2 in Phoenix.LiveReloader.before_send_inject_reloader/2
    (elixir) lib/enum.ex:1811: Enum."-reduce/3-lists^foldl/2-0-"/3
    (plug) lib/plug/conn.ex:1133: Plug.Conn.run_before_send/2
    (plug) lib/plug/conn.ex:432: Plug.Conn.send_file/5
```