### PR TITLE
Update FileSystem to avoid process leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ end
 
 ## Backends
 
-This project uses [`fs`](https://github.com/synrc/fs) as a dependency to watch your filesystem whenever there is a change and it supports the following operating systems:
+This project uses [`FileSystem`](https://github.com/falood/file_system) as a dependency to watch your filesystem whenever there is a change and it supports the following operating systems:
 
 * Linux via [inotify](https://github.com/rvoicilas/inotify-tools/wiki) (installation required)
 * Windows via [inotify-win](https://github.com/thekid/inotify-win) (no installation required)

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule PhoenixLiveReload.Mixfile do
       {:phoenix, "~> 1.0 or ~> 1.2 or ~> 1.3"},
       {:ex_doc, "~> 0.11", only: :docs},
       {:earmark, ">= 0.0.0", only: :docs},
-      {:file_system, "~> 0.2"},
+      {:file_system, "~> 0.2.1"},
     ]
   end
 end


### PR DESCRIPTION
`inotifywait` leaks after transition to FileSystem, which prevents Phoenix Live Reload from working properly after a few start/exit cycles. See falood/file_system#39.
```
$ mix phx.server
Failed to watch /app; upper limit on inotify watches reached!
Please increase the amount of inotify watches allowed per user via `/proc/sys/fs/inotify/max_user_watches'.
[info] Running SampleWeb.Endpoint with Cowboy using http://0.0.0.0:4
```
Patched in FileSystem 0.2.1.