### PR TITLE
IE11 compatibility for live-reloading JS

### DIFF
--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -2,7 +2,11 @@ var buildFreshUrl = function(link){
   var date    = Math.round(Date.now() / 1000).toString();
   var url     = link.href.replace(/(\&|\\?)vsn=\d*/, '');
   var newLink = document.createElement('link');
-  var onComplete = function() { link.remove() }
+  var onComplete = function() {
+    if (link.parentNode !== null) {
+      link.parentNode.removeChild(link);
+    }
+  };
 
   newLink.onerror = onComplete
   newLink.onload  = onComplete


### PR DESCRIPTION
Uses `link.parentNode.removeChild(link)` (instead of `link.remove()`) in `phoenix_live_reload.js` for the sake of IE11 compatibility.

(See https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove for more information, a browser compatibility chart, and a reference for the polyfill I'm aping.)