### PR TITLE
remove transport/3 from socket

### DIFF
--- a/lib/phoenix_live_reload/socket.ex
+++ b/lib/phoenix_live_reload/socket.ex
@@ -6,9 +6,6 @@ defmodule Phoenix.LiveReloader.Socket do
   use Phoenix.Socket
   channel "phoenix:live_reload", Phoenix.LiveReloader.Channel
 
-  transport :websocket, Phoenix.Transports.WebSocket
-  transport :longpoll, Phoenix.Transports.LongPoll
-
   def connect(_params, socket), do: {:ok, socket}
 
   def id(_socket), do: nil


### PR DESCRIPTION
`transport/3` is deprecated in Phoenix 1.4+