### PR TITLE
Allow passing custom directories and backend options

### DIFF
--- a/lib/phoenix_live_reload/application.ex
+++ b/lib/phoenix_live_reload/application.ex
@@ -10,7 +10,13 @@ defmodule Phoenix.LiveReloader.Application do
   end
 
   def start_link do
-    opts = [dirs: [Path.absname("")], name: :phoenix_live_reload_file_monitor]
+    dirs = Application.get_env(:phoenix_live_reload, :dirs, [""])
+    backend_opts = Application.get_env(:phoenix_live_reload, :backend_opts, [])
+
+    opts = [
+      name: :phoenix_live_reload_file_monitor,
+      dirs: Enum.map(dirs, &Path.absname/1),
+    ] ++ backend_opts
 
     opts =
       if backend = Application.get_env(:phoenix_live_reload, :backend) do


### PR DESCRIPTION
The FileSystem module is leveraged to monitor file changes, which allows passing a list of directories, and any backend-specific options.

These options are now exposed via the ```:dirs``` and ```:backend_opts``` to the ```:phoenix_live_reload``` config.

These changes are particularly useful in Vagrant/Virtualbox environments, where:
 * The ```:fs_poll``` backend is needed, and it has an ```:interval``` option to control the monitoring interval
 * Monitoring the entire application directory (the current hard-coded option) leads to dog slow live reload times (15-20 seconds in my testing), whereas target monitoring the necessary directories gives good reload response times.

Config would look like, eg.:

```elixir
config :phoenix_live_reload,
  dirs: [
    "priv/static",
    "priv/gettext",
    "lib/example_web/views",
    "lib/example_web/templates",
  ],
  backend: :fs_poll,
  backend_opts: [
    interval: 500
  ]
```

Finally, I'm not convinced I've taken the best approach to implement this feature. My goal was to preserve backwards compatibility while allowing straightforward customization for those who need it.