### PR TITLE
Use window.parent instead of window.top for reload

### DIFF
--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -1,4 +1,4 @@
-var buildFreshUrl = function(link) {
+var buildFreshUrl = function(link){
   var date = Math.round(Date.now() / 1000).toString();
   var url = link.href.replace(/(\&|\\?)vsn=\d*/, '');
   var newLink = document.createElement('link');
@@ -9,46 +9,37 @@ var buildFreshUrl = function(link) {
   };
 
   newLink.onerror = onComplete;
-  newLink.onload = onComplete;
+  newLink.onload  = onComplete;
   link.setAttribute('data-pending-removal', '');
   newLink.setAttribute('rel', 'stylesheet');
   newLink.setAttribute('type', 'text/css');
-  newLink.setAttribute(
-    'href',
-    url + (url.indexOf('?') >= 0 ? '&' : '?') + 'vsn=' + date
-  );
+  newLink.setAttribute('href', url + (url.indexOf('?') >= 0 ? '&' : '?') +'vsn=' + date);
   link.parentNode.insertBefore(newLink, link.nextSibling);
 
   return newLink;
 };
 
-var repaint = function() {
+var repaint = function(){
   var browser = navigator.userAgent.toLowerCase();
-  if (browser.indexOf('chrome') > -1) {
-    setTimeout(function() {
-      document.body.offsetHeight;
-    }, 25);
+  if(browser.indexOf('chrome') > -1){
+    setTimeout(function(){ document.body.offsetHeight; }, 25);
   }
 };
 
-var cssStrategy = function() {
+var cssStrategy = function(){
   var reloadableLinkElements = window.parent.document.querySelectorAll(
     'link[rel=stylesheet]:not([data-no-reload]):not([data-pending-removal])'
   );
 
   [].slice
     .call(reloadableLinkElements)
-    .filter(function(link) {
-      return link.href;
-    })
-    .forEach(function(link) {
-      buildFreshUrl(link);
-    });
+    .filter(function(link) { return link.href })
+    .forEach(function(link) { buildFreshUrl(link) });
 
   repaint();
 };
 
-var pageStrategy = function(chan) {
+var pageStrategy = function(chan){
   chan.off('assets_change');
   window.parent.location.reload();
 };
@@ -59,12 +50,9 @@ var reloadStrategies = {
 };
 
 socket.connect();
-var chan = socket.channel('phoenix:live_reload', {});
+var chan = socket.channel('phoenix:live_reload', {})
 chan.on('assets_change', function(msg) {
-  var reloadStrategy =
-    reloadStrategies[msg.asset_type] || reloadStrategies.page;
-  setTimeout(function() {
-    reloadStrategy(chan);
-  }, interval);
+  var reloadStrategy = reloadStrategies[msg.asset_type] || reloadStrategies.page;
+  setTimeout(function(){ reloadStrategy(chan); }, interval);
 });
 chan.join();

--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -1,4 +1,4 @@
-var buildFreshUrl = function(link){
+var buildFreshUrl = function(link) {
   var date = Math.round(Date.now() / 1000).toString();
   var url = link.href.replace(/(\&|\\?)vsn=\d*/, '');
   var newLink = document.createElement('link');
@@ -9,39 +9,48 @@ var buildFreshUrl = function(link){
   };
 
   newLink.onerror = onComplete;
-  newLink.onload  = onComplete;
+  newLink.onload = onComplete;
   link.setAttribute('data-pending-removal', '');
   newLink.setAttribute('rel', 'stylesheet');
   newLink.setAttribute('type', 'text/css');
-  newLink.setAttribute('href', url + (url.indexOf('?') >= 0 ? '&' : '?') +'vsn=' + date);
+  newLink.setAttribute(
+    'href',
+    url + (url.indexOf('?') >= 0 ? '&' : '?') + 'vsn=' + date
+  );
   link.parentNode.insertBefore(newLink, link.nextSibling);
 
   return newLink;
 };
 
-var repaint = function(){
+var repaint = function() {
   var browser = navigator.userAgent.toLowerCase();
-  if(browser.indexOf('chrome') > -1){
-    setTimeout(function(){ document.body.offsetHeight; }, 25);
+  if (browser.indexOf('chrome') > -1) {
+    setTimeout(function() {
+      document.body.offsetHeight;
+    }, 25);
   }
 };
 
-var cssStrategy = function(){
+var cssStrategy = function() {
   var reloadableLinkElements = window.parent.document.querySelectorAll(
     'link[rel=stylesheet]:not([data-no-reload]):not([data-pending-removal])'
   );
 
   [].slice
     .call(reloadableLinkElements)
-    .filter(function(link) { return link.href })
-    .forEach(function(link) { buildFreshUrl(link) });
+    .filter(function(link) {
+      return link.href;
+    })
+    .forEach(function(link) {
+      buildFreshUrl(link);
+    });
 
   repaint();
 };
 
-var pageStrategy = function(chan){
+var pageStrategy = function(chan) {
   chan.off('assets_change');
-  window.top.location.reload();
+  window.parent.location.reload();
 };
 
 var reloadStrategies = {
@@ -50,9 +59,12 @@ var reloadStrategies = {
 };
 
 socket.connect();
-var chan = socket.channel('phoenix:live_reload', {})
+var chan = socket.channel('phoenix:live_reload', {});
 chan.on('assets_change', function(msg) {
-  var reloadStrategy = reloadStrategies[msg.asset_type] || reloadStrategies.page;
-  setTimeout(function(){ reloadStrategy(chan); }, interval);
+  var reloadStrategy =
+    reloadStrategies[msg.asset_type] || reloadStrategies.page;
+  setTimeout(function() {
+    reloadStrategy(chan);
+  }, interval);
 });
 chan.join();


### PR DESCRIPTION
Using window.parent allows live reload to work if the application we're working on is embedded within an iframe in another site.

This is common in the case of widgets.

It was mentioned in #72 that "in some cases it's good that we are refreshing whole page instead of iframe's content" but I'm struggling to think of when it makes sense to refresh the whole page instead of just the thing that has changed (or maybe I just haven't run into that case)?