### PR TITLE
Scoped live reload

### DIFF
--- a/test/live_reloader_test.exs
+++ b/test/live_reloader_test.exs
@@ -77,4 +77,15 @@ defmodule Phoenix.LiveReloaderTest do
     refute to_string(conn.resp_body) =~
            ~s(<iframe src="/phoenix/live_reload/frame")
   end
+
+  test "injects scoped live_reload for html requests if configured and contains <body> tag" do
+    opts = Phoenix.LiveReloader.init([])
+    conn = conn("/")
+           |> put_private(:phoenix_endpoint, MyApp.EndpointSuffix)
+           |> put_resp_content_type("text/html")
+           |> Phoenix.LiveReloader.call(opts)
+           |> send_resp(200, "<html><body><h1>Phoenix</h1></body></html>")
+    assert to_string(conn.resp_body) ==
+      "<html><body><h1>Phoenix</h1><iframe src=\"/phoenix/live_reload/frame/foo/bar\" style=\"display: none;\"></iframe>\n</body></html>"
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -16,13 +16,27 @@ Application.put_env(:phoenix_live_reload, MyApp.EndpointScript, [
   url: [path: "/foo/bar"],
 ])
 
+Application.put_env(:phoenix_live_reload, MyApp.EndpointSuffix,
+  live_reload:
+    [url: "ws://localhost:4000",
+     suffix: "/foo/bar",
+     patterns: [
+       ~r{priv/static/.*(js|css|png|jpeg|jpg|gif)$},
+       ~r{web/views/.*(ex)$},
+       ~r{web/templates/.*(eex)$}
+     ]])
+
 defmodule MyApp.Endpoint do
   use Phoenix.Endpoint, otp_app: :phoenix_live_reload
 end
 defmodule MyApp.EndpointScript do
   use Phoenix.Endpoint, otp_app: :phoenix_live_reload
 end
+defmodule MyApp.EndpointSuffix do
+  use Phoenix.Endpoint, otp_app: :phoenix_live_reload
+end
 
 MyApp.Endpoint.start_link()
 MyApp.EndpointScript.start_link()
+MyApp.EndpointSuffix.start_link()
 ExUnit.start()


### PR DESCRIPTION
Hey 😄 

This commit adds the possibility to define a scope for the live reload. The problem arose while I was developing an umbrella app which had 2 phoenix apps. Live reload would use the config of the last app which got loaded by the umbrella app.

So for example given the following two apps config:

`apps/app_one/config/dev.exs`:
```elixir
config :app_one, AppOneWeb.Endpoint,
  live_reload: [
    patterns: [
      ~r"priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$",
      ~r"priv/gettext/.*(po)$",
      ~r"lib/app_one_web/{live,views}/.*(ex)$",
      ~r"lib/app_one_web/templates/.*(eex)$"
    ]
  ]
```
`apps/app_two/config/dev.exs`:
```elixir
config :app_two, AppTwoWeb.Endpoint,
  live_reload: [
    patterns: [
      ~r"priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$",
      ~r"priv/gettext/.*(po)$",
      ~r"lib/app_two_web/{live,views}/.*(ex)$",
      ~r"lib/app_two_web/templates/.*(eex)$"
    ]
  ]
```

Only the `patterns` of `app_two` would ever get used by live reload, so the pages of `app_one` were not reloading when the templates or views of `app_one` were updated. Actually they would get reloaded when templates or views were updated in `app_two`.

They did "cross" reload on static asset changes though (they would both reload when either js or css was updated in either of them) – this commit doesn't resolve this issue.

So the way I solved this was by adding a `scope` option to the live reload configuration, like this:

`apps/app_one/config/dev.exs`:
```elixir
config :app_one, AppOneWeb.Endpoint,
  live_reload: [
    scope: "/app_one",
    patterns: [
      ~r"priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$",
      ~r"priv/gettext/.*(po)$",
      ~r"lib/app_one_web/{live,views}/.*(ex)$",
      ~r"lib/app_one_web/templates/.*(eex)$"
    ]
  ]
```

`apps/app_one/lib/app_one_web/endpoint.ex`:
```elixir
if code_reloading? do
  socket "/app_one/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
  ...
end
```

I added a test also for this case. Would love to hear your thoughts on this, thanks 😄 