### PR TITLE
Add test to check if the plug works with iolists

### DIFF
--- a/test/live_reloader_test.exs
+++ b/test/live_reloader_test.exs
@@ -88,4 +88,15 @@ defmodule Phoenix.LiveReloaderTest do
     assert to_string(conn.resp_body) ==
       "<html><body><h1>Phoenix</h1><iframe src=\"/phoenix/live_reload/frame/foo/bar\" style=\"display: none;\"></iframe>\n</body></html>"
   end
+
+  test "works with iolists as input" do
+    opts = Phoenix.LiveReloader.init([])
+    conn = conn("/")
+           |> put_private(:phoenix_endpoint, MyApp.EndpointSuffix)
+           |> put_resp_content_type("text/html")
+           |> Phoenix.LiveReloader.call(opts)
+           |> send_resp(200, ["<html>", '<bo', [?d, ?y | ">"], "<h1>Phoenix</h1>", "</b", ?o, 'dy>', "</html>"])
+    assert to_string(conn.resp_body) ==
+      "<html><body><h1>Phoenix</h1><iframe src=\"/phoenix/live_reload/frame/foo/bar\" style=\"display: none;\"></iframe>\n</body></html>"
+  end
 end


### PR DESCRIPTION
This uses complex `iolist` that should be handled properly according to
the `Plug.Conn` and `Phoenix.LiveReloader` documentation.