### PR TITLE
Convert interval to String for iolist

### DIFF
--- a/lib/phoenix_live_reload/live_reloader.ex
+++ b/lib/phoenix_live_reload/live_reloader.ex
@@ -94,7 +94,7 @@ defmodule Phoenix.LiveReloader do
     |> send_resp(200, [
       @html_before,
       ~s[var socket = new Phoenix.Socket("], url, ~s[");\n],
-      "var interval = ", interval, ";\n",
+      "var interval = ", Integer.to_string(interval), ";\n",
       @html_after
     ])
     |> halt()


### PR DESCRIPTION
Otherwise the default `100` gets output as `var interval = d;\n`