### PR TITLE
Replace Style Attr with Hidden

### DIFF
--- a/lib/phoenix_live_reload/live_reloader.ex
+++ b/lib/phoenix_live_reload/live_reloader.ex
@@ -34,10 +34,7 @@ defmodule Phoenix.LiveReloader do
       This option is required to enable any live reloading.
 
     * `:iframe_class` - a class to be used to be given to the iframe
-      injected by live reload. By default the iframe uses a "style"
-      attribute to hide itself but that can conflict with Content
-      Security Policies. By giving a class, you disable the default
-      style and control the styling of the iframe.
+      injected by live reload.
 
     * `:url` - the URL of the live reload socket connection. By default
       it will use the browser's host and port.
@@ -143,9 +140,9 @@ defmodule Phoenix.LiveReloader do
     path = conn.private.phoenix_endpoint.path("/phoenix/live_reload/frame#{suffix(endpoint)}")
 
     if class = config[:iframe_class] do
-      ~s[<iframe src="#{path}" class="#{class}"></iframe>]
+      ~s[<iframe src="#{path}" hidden class="#{class}"></iframe>]
     else
-      ~s[<iframe src="#{path}" style="display: none;"></iframe>]
+      ~s[<iframe src="#{path}" hidden></iframe>]
     end
   end
 

--- a/test/live_reloader_test.exs
+++ b/test/live_reloader_test.exs
@@ -37,7 +37,7 @@ defmodule Phoenix.LiveReloaderTest do
            |> Phoenix.LiveReloader.call(opts)
            |> send_resp(200, "<html><body><h1>Phoenix</h1></body></html>")
     assert to_string(conn.resp_body) ==
-      "<html><body><h1>Phoenix</h1><iframe src=\"/phoenix/live_reload/frame\" style=\"display: none;\"></iframe></body></html>"
+      "<html><body><h1>Phoenix</h1><iframe src=\"/phoenix/live_reload/frame\" hidden></iframe></body></html>"
   end
 
   test "injects live_reload with script_name" do
@@ -48,7 +48,7 @@ defmodule Phoenix.LiveReloaderTest do
            |> Phoenix.LiveReloader.call(opts)
            |> send_resp(200, "<html><body><h1>Phoenix</h1></body></html>")
     assert to_string(conn.resp_body) ==
-      "<html><body><h1>Phoenix</h1><iframe src=\"/foo/bar/phoenix/live_reload/frame\" style=\"display: none;\"></iframe></body></html>"
+      "<html><body><h1>Phoenix</h1><iframe src=\"/foo/bar/phoenix/live_reload/frame\" hidden></iframe></body></html>"
   end
 
   test "skips live_reload injection if html response missing body tag" do
@@ -89,7 +89,7 @@ defmodule Phoenix.LiveReloaderTest do
            |> Phoenix.LiveReloader.call(opts)
            |> send_resp(200, "<html><body><h1>Phoenix</h1></body></html>")
     assert to_string(conn.resp_body) ==
-      "<html><body><h1>Phoenix</h1><iframe src=\"/phoenix/live_reload/frame/foo/bar\" class=\"d-none\"></iframe></body></html>"
+      "<html><body><h1>Phoenix</h1><iframe src=\"/phoenix/live_reload/frame/foo/bar\" hidden class=\"d-none\"></iframe></body></html>"
   end
 
   test "works with iolists as input" do
@@ -100,6 +100,6 @@ defmodule Phoenix.LiveReloaderTest do
            |> Phoenix.LiveReloader.call(opts)
            |> send_resp(200, ["<html>", '<bo', [?d, ?y | ">"], "<h1>Phoenix</h1>", "</b", ?o, 'dy>', "</html>"])
     assert to_string(conn.resp_body) ==
-      "<html><body><h1>Phoenix</h1><iframe src=\"/phoenix/live_reload/frame\" style=\"display: none;\"></iframe></body></html>"
+      "<html><body><h1>Phoenix</h1><iframe src=\"/phoenix/live_reload/frame\" hidden></iframe></body></html>"
   end
 end


### PR DESCRIPTION
This solution does not use inline styles and is therefore less of a problem to use with a CSP.

FYI: The `hidden` attribute is supported globally by 99.04% of users.(>= IE 11)

https://caniuse.com/hidden