### PR TITLE
Fix unexpected quirks mode notification in Chrome

### DIFF
--- a/lib/phoenix_live_reload/live_reloader.ex
+++ b/lib/phoenix_live_reload/live_reloader.ex
@@ -72,6 +72,7 @@ defmodule Phoenix.LiveReloader do
   @external_resource reload_path
 
   @html_before """
+  <!DOCTYPE html>
   <html><body>
   <script>
   #{File.read!(phoenix_path) |> String.replace("//# sourceMappingURL=", "// ")}


### PR DESCRIPTION
Chrome (Version 94.0.4606.71 (Official Build) (x86_64)) is reporting an issue in dev tools due to missing DOCTYPE.

![Screen Shot 2021-10-10 at 1 47 02 pm](https://user-images.githubusercontent.com/703621/136721787-d941e22d-37a8-4c9e-a73e-1f5c15064238.png)

The issue nor this suggested fix appears to impact live reload in anyway beyond removing the report in Chrome dev tools.