### PR TITLE
feat: Add option to trigger full page reloads on css changes

### DIFF
--- a/lib/phoenix_live_reload/live_reloader.ex
+++ b/lib/phoenix_live_reload/live_reloader.ex
@@ -60,6 +60,7 @@ defmodule Phoenix.LiveReloader do
             socket "/phoenix/live_reload/socket/proxied/app/path", Phoenix.LiveReloader.Socket
             ...
           end
+
     * `:reload_page_on_css_changes` - If true, CSS changes will trigger a full
       page reload like other asset types instead of the default hot reload.
       Useful when class names are determined at runtime, for example when

--- a/lib/phoenix_live_reload/live_reloader.ex
+++ b/lib/phoenix_live_reload/live_reloader.ex
@@ -60,6 +60,10 @@ defmodule Phoenix.LiveReloader do
             socket "/phoenix/live_reload/socket/proxied/app/path", Phoenix.LiveReloader.Socket
             ...
           end
+    * `:reload_page_on_css_changes` - If true, CSS changes will trigger a full
+      page reload like other asset types instead of the default hot reload.
+      Useful when class names are determined at runtime, for example when
+      working with CSS modules. Defaults to false.
 
   """
 
@@ -94,6 +98,7 @@ defmodule Phoenix.LiveReloader do
     url = config[:url] || endpoint.path("/phoenix/live_reload/socket#{suffix(endpoint)}")
     interval = config[:interval] || 100
     target_window = get_target_window(config[:target_window])
+    reload_page_on_css_changes? = config[:reload_page_on_css_changes] || false
 
     conn
     |> put_resp_content_type("text/html")
@@ -102,6 +107,7 @@ defmodule Phoenix.LiveReloader do
       ~s[var socket = new Phoenix.Socket("#{url}");\n],
       ~s[var interval = #{interval};\n],
       ~s[var targetWindow = "#{target_window}";\n],
+      ~s[var reloadPageOnCssChanges = #{reload_page_on_css_changes?};\n],
       @html_after
     ])
     |> halt()
@@ -198,5 +204,4 @@ defmodule Phoenix.LiveReloader do
   defp get_target_window(:parent), do: "parent"
 
   defp get_target_window(_), do: "top"
-
 end

--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -45,7 +45,7 @@ var pageStrategy = function(chan){
 };
 
 var reloadStrategies = {
-  css: cssStrategy,
+  css: reloadPageOnCssChanges ? pageStrategy : cssStrategy,
   page: pageStrategy
 };
 

--- a/test/live_reloader_test.exs
+++ b/test/live_reloader_test.exs
@@ -30,6 +30,9 @@ defmodule Phoenix.LiveReloaderTest do
     assert to_string(conn.resp_body) =~
              ~s[var targetWindow = "top";\n]
 
+    assert to_string(conn.resp_body) =~
+             ~s[var reloadPageOnCssChanges = false;\n]
+
     refute to_string(conn.resp_body) =~
              ~s[<iframe]
   end
@@ -170,5 +173,4 @@ defmodule Phoenix.LiveReloaderTest do
     assert to_string(conn.resp_body) =~
       ~s[var targetWindow = "top";\n]
   end
-
 end


### PR DESCRIPTION
Fixes https://github.com/phoenixframework/phoenix_live_reload/issues/122

Adds a configuration option to trigger full page reloads when a CSS asset changes.

In the client, if the option is true, the strategy for reloading css files is set to `pageStrategy`, which is the same as what is used by all other asset types.