### PR TITLE
Fix compilation warnings on newest Elixir

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
 config :phoenix, :json_library, Jason

--- a/lib/phoenix_live_reload/application.ex
+++ b/lib/phoenix_live_reload/application.ex
@@ -29,7 +29,7 @@ defmodule Phoenix.LiveReloader.Application do
         {:ok, pid}
 
       other ->
-        Logger.warn("""
+        Logger.warning("""
         Could not start Phoenix live-reload because we cannot listen to the file system.
         You don't need to worry! This is an optional feature used during development to
         refresh your browser when you save files and it does not affect production.

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule PhoenixLiveReload.Mixfile do
     [
       app: :phoenix_live_reload,
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.11",
       deps: deps(),
 
       # Hex


### PR DESCRIPTION
When compiling this project with Elixir 1.15 we get two warnings:
1. `use Mix.Config is deprecated. Use the Config module instead`. [Deprecated since Elixir 1.9](https://hexdocs.pm/mix/1.9.0/Mix.Config.html)
2. `Logger.warn/1 is deprecated. Use Logger.warning/2 instead`. [Deprecated since Elixir 1.15](https://hexdocs.pm/logger/1.15.0/Logger.html#warn/2)

This pull request fixes both deprecation warnings and bumps the minimum required Elixir version to 1.11 to ensure that the non-deprecated alternatives are supported. Otherwise we would have to use different code depending on the Elixir version.

Bumping the required Elixir version to 1.11 is a breaking change but was discussed in phoenixframework/phoenix_live_reload#137.

