### PR TITLE
Feature: allow opt-in scroll restoration

### DIFF
--- a/lib/phoenix_live_reload/live_reloader.ex
+++ b/lib/phoenix_live_reload/live_reloader.ex
@@ -125,8 +125,8 @@ defmodule Phoenix.LiveReloader do
     config = endpoint.config(:live_reload)
     url = config[:url] || endpoint.path("/phoenix/live_reload/socket#{suffix(endpoint)}")
     interval = config[:interval] || 100
-    restore_scroll_on_reload = config[:restore_scroll_on_reload] || false
     target_window = get_target_window(config[:target_window])
+    restore_scroll_on_reload? = config[:restore_scroll_on_reload] || false
     reload_page_on_css_changes? = config[:reload_page_on_css_changes] || false
 
     conn
@@ -136,7 +136,7 @@ defmodule Phoenix.LiveReloader do
       ~s[var socket = new Phoenix.Socket("#{url}");\n],
       ~s[var interval = #{interval};\n],
       ~s[var targetWindow = "#{target_window}";\n],
-      ~s[var restoreScrollOnReload = #{restore_scroll_on_reload};\n],
+      ~s[var restoreScrollOnReload = #{restore_scroll_on_reload?};\n],
       ~s[var reloadPageOnCssChanges = #{reload_page_on_css_changes?};\n],
       @html_after
     ])

--- a/lib/phoenix_live_reload/live_reloader.ex
+++ b/lib/phoenix_live_reload/live_reloader.ex
@@ -65,6 +65,10 @@ defmodule Phoenix.LiveReloader do
             ...
           end
 
+    * `:restore_scroll_on_reload` - If true, the scrollY position will be
+      restored after full page reloads. This is helpful when working on content
+      far below the fold. Defaults to false.
+
     * `:reload_page_on_css_changes` - If true, CSS changes will trigger a full
       page reload like other asset types instead of the default hot reload.
       Useful when class names are determined at runtime, for example when
@@ -121,6 +125,7 @@ defmodule Phoenix.LiveReloader do
     config = endpoint.config(:live_reload)
     url = config[:url] || endpoint.path("/phoenix/live_reload/socket#{suffix(endpoint)}")
     interval = config[:interval] || 100
+    restore_scroll_on_reload = config[:restore_scroll_on_reload] || false
     target_window = get_target_window(config[:target_window])
     reload_page_on_css_changes? = config[:reload_page_on_css_changes] || false
 
@@ -131,6 +136,7 @@ defmodule Phoenix.LiveReloader do
       ~s[var socket = new Phoenix.Socket("#{url}");\n],
       ~s[var interval = #{interval};\n],
       ~s[var targetWindow = "#{target_window}";\n],
+      ~s[var restoreScrollOnReload = #{restore_scroll_on_reload};\n],
       ~s[var reloadPageOnCssChanges = #{reload_page_on_css_changes?};\n],
       @html_after
     ])

--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -56,7 +56,7 @@ var chan = socket.channel('phoenix:live_reload', {})
 chan.on('assets_change', function(msg) {
   var reloadStrategy = reloadStrategies[msg.asset_type] || reloadStrategies.page;
 
-  if (restoreScrollOnReload) {
+  if (restoreScrollOnReload && reloadStrategy === pageStrategy) {
     sessionStorage.setItem(SESSION_STORAGE_SCROLL_Y_KEY, window[targetWindow].scrollY);
   }
 

--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -60,7 +60,6 @@ socket.connect();
 var chan = socket.channel('phoenix:live_reload', {})
 chan.on('assets_change', function(msg) {
   var reloadStrategy = reloadStrategies[msg.asset_type] || reloadStrategies.page;
-
   setTimeout(function(){ reloadStrategy(chan); }, interval);
 });
 

--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -43,6 +43,11 @@ var cssStrategy = function(){
 
 var pageStrategy = function(chan){
   chan.off('assets_change');
+
+  if (restoreScrollOnReload) {
+    sessionStorage.setItem(SESSION_STORAGE_SCROLL_Y_KEY, window[targetWindow].scrollY);
+  }
+
   window[targetWindow].location.reload();
 };
 
@@ -55,10 +60,6 @@ socket.connect();
 var chan = socket.channel('phoenix:live_reload', {})
 chan.on('assets_change', function(msg) {
   var reloadStrategy = reloadStrategies[msg.asset_type] || reloadStrategies.page;
-
-  if (restoreScrollOnReload && reloadStrategy === pageStrategy) {
-    sessionStorage.setItem(SESSION_STORAGE_SCROLL_Y_KEY, window[targetWindow].scrollY);
-  }
 
   setTimeout(function(){ reloadStrategy(chan); }, interval);
 });

--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -65,12 +65,12 @@ chan.on('assets_change', function(msg) {
 
 var optionallyRestoreScroll = function() {
   if (restoreScrollOnReload) {
-    const scrollY = sessionStorage.getItem(SESSION_STORAGE_SCROLL_Y_KEY)
+    const scrollYSerialized = sessionStorage.getItem(SESSION_STORAGE_SCROLL_Y_KEY)
 
-    if (scrollY) {
-      const int = parseInt(scrollY, 10)
+    if (scrollYSerialized) {
+      const scrollY = parseInt(scrollYSerialized, 10)
 
-      window[targetWindow].scrollTo(0, int);
+      window[targetWindow].scrollTo(0, scrollY);
       sessionStorage.removeItem(SESSION_STORAGE_SCROLL_Y_KEY);
     }
   }


### PR DESCRIPTION
This pull request adds opt-in scroll restoration after full reloads, as proposed in #144, as this is helpful when working on components or content far below the fold.

