### PR TITLE
Handle more log types (ie notice)

### DIFF
--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -125,8 +125,8 @@ class LiveReloader {
   }
 
   log(level, str){
-    let levelColor = {debug: "cyan", info: "inherit", error: "inherit"}[level]
-    let consoleFunc = level === "debug" ? "info" : level
+    let levelColor = level === "debug" ? "cyan" : "inherit"
+    let consoleFunc = level === "error" ? level : "info"
     console[consoleFunc](`%c📡 [${level}] ${str}`, `color: ${levelColor};`)
   }
 


### PR DESCRIPTION
Whilst giving the latest web console logger a spin, I was receiving console errors from the `log` js function for our 'notice' logs.

I simplified the `levelColor` variable, but alternatively it could be more like below to keep with the current style, but i'm sure their is probably a better way still

```js
{
    debug: "cyan", 
    info: "inherit", 
    notice: "inherit", 
    warning: "inherit", 
    error: "inherit", 
    critical: "inherit", 
    alert: "inherit", 
    emergency: "inherit"
}[level]
```