### PR TITLE
load dependencies in application start callback

### DIFF
--- a/lib/phoenix_live_reload/application.ex
+++ b/lib/phoenix_live_reload/application.ex
@@ -9,6 +9,10 @@ defmodule Phoenix.LiveReloader.Application do
     # be started in dev via user's `only: :dev` entry.
     WebConsoleLogger.attach_logger()
 
+    # the deps paths are read by the channel when getting the full_path for
+    # opening the configured PLUG_EDITOR
+    :persistent_term.put(:phoenix_live_reload_deps_paths, deps_paths())
+
     children = [
       WebConsoleLogger,
       %{id: __MODULE__, start: {__MODULE__, :start_link, []}}
@@ -46,6 +50,15 @@ defmodule Phoenix.LiveReloader.Application do
         """)
 
         other
+    end
+  end
+
+  defp deps_paths do
+    # TODO: Use `Code.loaded?` on Elixir v1.15+
+    if :erlang.module_loaded(Mix.Project) do
+      for {app, path} <- Mix.Project.deps_paths(), into: %{}, do: {to_string(app), path}
+    else
+      %{}
     end
   end
 end

--- a/lib/phoenix_live_reload/channel.ex
+++ b/lib/phoenix_live_reload/channel.ex
@@ -26,7 +26,6 @@ defmodule Phoenix.LiveReloader.Channel do
         |> assign(:patterns, config[:patterns] || [])
         |> assign(:debounce, config[:debounce] || 0)
         |> assign(:notify_patterns, config[:notify] || [])
-        |> assign(:deps_paths, deps_paths())
 
       {:ok, join_info(), socket}
     else
@@ -76,7 +75,7 @@ defmodule Phoenix.LiveReloader.Channel do
   end
 
   def handle_in("full_path", %{"rel_path" => rel_path, "app" => app}, socket) do
-    case socket.assigns.deps_paths do
+    case :persistent_term.get(:phoenix_live_reload_deps_paths) do
       %{^app => dep_path} ->
         {:reply, {:ok, %{full_path: Path.join(dep_path, rel_path)}}, socket}
 
@@ -126,15 +125,6 @@ defmodule Phoenix.LiveReloader.Channel do
   defp join_info do
     if url = System.get_env("PLUG_EDITOR") do
       %{editor_url: url}
-    else
-      %{}
-    end
-  end
-
-  defp deps_paths do
-    # TODO: Use `Code.loaded?` on Elixir v1.15+
-    if :erlang.module_loaded(Mix.Project) do
-      for {app, path} <- Mix.Project.deps_paths(), into: %{}, do: {to_string(app), path}
     else
       %{}
     end


### PR DESCRIPTION
When using the new PLUG_EDITOR integration, there was a problem where not all dependencies were available when the code reloader recompiled the code.
This lead to missing dependencies when the live reloader joined the channel.
This change ensures that all we initially load the deps when the application starts, so that later recompiles don't affect the deps list.