### PR TITLE
Update css reload strategy

### DIFF
--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -30,7 +30,7 @@ let cssStrategy = () => {
     "link[rel=stylesheet]:not([data-no-reload]):not([data-pending-removal])"
   )
 
-  ([].slice).call(reloadableLinkElements)
+  Array.from(reloadableLinkElements)
     .filter(link => link.href)
     .forEach(link => buildFreshUrl(link))
 


### PR DESCRIPTION
Live reload was not loading on css changes. This update seems to fix it.

![Bug](https://github.com/phoenixframework/phoenix_live_reload/assets/5104850/3f23d2ce-ff12-410d-8b80-45af0cf88cb0)
