### PR TITLE
web logger: using the appropriate console function level

### DIFF
--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -126,8 +126,27 @@ class LiveReloader {
 
   log(level, str){
     let levelColor = level === "debug" ? "darkcyan" : "inherit"
-    let consoleFunc = level === "error" ? level : "log"
-    console[consoleFunc](`%c📡 ${str}`, `color: ${levelColor};`)
+    let consoleFunc = this.logFunc(level)
+    this.logMsg(consoleFunc, str, levelColor)
+  }
+
+  logMsg(fun, str, color) {
+    fun(`%c📡 ${str}`, `color: ${color};`)
+  }
+  
+  logFunc(level){
+    switch(level) {
+      case "debug":
+        return console.debug;
+      case "info":
+        return console.info;
+      case "warning":
+        return console.warn;
+      case "error":
+        return console.error;
+      default:
+        return console.log;
+    }
   }
 
   closestCallerFileLine(node){

--- a/priv/static/phoenix_live_reload.js
+++ b/priv/static/phoenix_live_reload.js
@@ -142,10 +142,8 @@ class LiveReloader {
         return console.info;
       case "warning":
         return console.warn;
-      case "error":
-        return console.error;
       default:
-        return console.log;
+        return console.error;
     }
   }
 


### PR DESCRIPTION
It will be nice if we can use the native console filters to filter out the severity levels:

![Screenshot from 2024-04-17 13-52-51](https://github.com/phoenixframework/phoenix_live_reload/assets/109541/115c277a-25f8-450b-bc30-db85c2e4b91e)
![Screenshot from 2024-04-17 13-52-36](https://github.com/phoenixframework/phoenix_live_reload/assets/109541/529f9365-ddb8-4fbb-b33f-08f18b247369)


I have tons of debug messages, so just filtering out with the existing browser features it will help a lot!

References:
- https://css-tricks.com/a-guide-to-console-commands/
- https://developer.mozilla.org/en-US/docs/Web/API/console

Thanks! Keep up the amazing work!