### PR TITLE
Fix file_system dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule PhoenixLiveReload.Mixfile do
       {:ex_doc, "~> 0.29", only: :docs},
       {:makeup_eex, ">= 0.1.1", only: :docs},
       {:makeup_diff, "~> 0.1", only: :docs},
-      {:file_system, "~> 0.3 or ~> 1.0"},
+      {:file_system, "~> 0.2.10 or ~> 1.0"},
       {:jason, "~> 1.0", only: :test}
     ]
   end


### PR DESCRIPTION
Hi :wave: 

We recently hit a dependency resolution failure where a package ([lightning_css](https://github.com/glossia/lightning_css)) depended on not-too-old `file_system ~> 0.2.10` and hence conflicted with `phoenix_live_reload`'s dependency. I've submitted a patch to this package as well to bump the dep to v1.0.0, but some more research led to the following interesting find:

- file_system used to be called ExFsWatch more than 7 years ago. This package had versions going up to v0.4.2
- After the rename to file_system, version numbering started again at v0.1.1 and went up to v0.2.10 until version was bumped to v1.0.0. Weirdly enough, this all happens in the same [repository](https://github.com/falood/file_system/commits) and there are tags for all versions.
- **There [never was](https://hex.pm/packages/file_system) a file_system v0.3.0** and the dependency in `mix.exs` is wrong. Looking at [recent changes](https://github.com/falood/file_system/commits/v1.0.0), it seems safe to still include `v0.2.10`.