### PR TITLE
Add README.md and CHANGELOG.md to the docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,10 +16,7 @@ defmodule PhoenixLiveReload.Mixfile do
 
       # Docs
       name: "Phoenix Live-Reload",
-      docs: [
-        source_ref: "v#{@version}",
-        source_url: "https://github.com/phoenixframework/phoenix_live_reload"
-      ]
+      docs: docs()
     ]
   end
 
@@ -46,6 +43,18 @@ defmodule PhoenixLiveReload.Mixfile do
       {:makeup_diff, "~> 0.1", only: :docs},
       {:file_system, "~> 0.2.10 or ~> 1.0"},
       {:jason, "~> 1.0", only: :test}
+    ]
+  end
+
+  defp docs do
+    [
+      main: "readme",
+      extras: [
+        "README.md",
+        "CHANGELOG.md"
+      ],
+      source_ref: "v#{@version}",
+      source_url: "https://github.com/phoenixframework/phoenix_live_reload"
     ]
   end
 end


### PR DESCRIPTION
I've been upgrading my app, and as part of the upgrade I bumped `phoenix_live_reload` to the latest version (v1.5.3). In the change log I found a mention of [`:web_console_logger`](https://github.com/phoenixframework/phoenix_live_reload/blob/e9160bde423f727036951aba92ddd6dbee674013/CHANGELOG.md#L23).

The [docs for `:web_console_logger`](https://github.com/phoenixframework/phoenix_live_reload/blob/e9160bde423f727036951aba92ddd6dbee674013/lib/phoenix_live_reload/live_reloader.ex#L73-L76) refer to `README.md` for instructions on how to setup streaming server logs to the web console, but `README.md` is not included in the docs, so I had to leave Hexdocs and go to Github to read the instructions.

In this PR I've added `README.md` and `CHANGELOG.md` to the docs, I've also made `README.md` the entry point of the docs (instead of the "API Reference" page).